### PR TITLE
docs: fix missing expose port instruction

### DIFF
--- a/ethereum-client/metrics/setting-up-local-metrics-infrastracture.md
+++ b/ethereum-client/metrics/setting-up-local-metrics-infrastracture.md
@@ -12,7 +12,7 @@ Nethermind metrics can be consumed by _Prometheus/Grafana_ if configured in [Met
 
 ### Enabling Metrics in Nethermind
 
-Metrics can be enabled by simply passing `--Metrics.Enabled true` argument to the Docker containers,`Nethermind.Runner` or `Nethermind.Launcher`  e.g. `./Nethermind.Runner --Metrics.Enabled true`. 
+Metrics can be enabled by simply passing `--Metrics.Enabled true --Metrics.ExposePort 6060` arguments to the Docker containers,`Nethermind.Runner` or `Nethermind.Launcher`  e.g. `./Nethermind.Runner --Metrics.Enabled true --Metrics.ExposePort 6060`. 
 
 `Metrics.PushGatewayUrl` will need to be amended if pushgateway endpoint is not default.
 


### PR DESCRIPTION
Nethermind won't actually expose the port with just `--Metrics.Enabled true`. You also need --Metrics.ExposePort 6060