### PR TITLE
Update Gnosis Chain Validator tooling

### DIFF
--- a/versioned_docs/version-v1.27.0/validators/validators.md
+++ b/versioned_docs/version-v1.27.0/validators/validators.md
@@ -54,4 +54,4 @@ These configurations have proven to work well for 1000-1500 validators and haven
 
 ## Gnosis validators
 
-To set up a Gnosis Chain validator, you can either do that [manually](https://docs.gnosischain.com/node/manual/) or use one of the available [one-click tools](https://docs.gnosischain.com/node/tools).
+To set up a Gnosis Chain validator, you can either do that [manually](https://docs.gnosischain.com/node/manual/) or use one of the available [one-click tools](https://docs.gnosischain.com/node/Node%20Tools/sedge).


### PR DESCRIPTION
Removed the deprecated link for the one click setup tool for running node on gnosis chain and pushed a new updated link