### PR TITLE
Update doc for admin_peers rpc to include inbound boolean field

### DIFF
--- a/versioned_docs/version-1.28.0/interacting/json-rpc-ns/admin.md
+++ b/versioned_docs/version-1.28.0/interacting/json-rpc-ns/admin.md
@@ -104,7 +104,7 @@ Information about this node
 
 ### admin_peers
 
-Displays a list of connected peers including information about them (`clientId`, `host`, `port`, `address`, `isBootnode`, `isStatic`, `enode`).
+Displays a list of connected peers including information about them (`clientId`, `host`, `port`, `address`, `isBootnode`, `isStatic`, `enode`, `inbound`).
 
 <Tabs>
 <TabItem value="params" label="Parameters">
@@ -152,6 +152,7 @@ List of connected peers including information
   - `isTrusted`: *boolean*
   - `lastSignal`: *string*
   - `port`: *string* (hex integer)
+  - `inbound`: *boolean*
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Adds the inbound boolean field to the `admin_peers` rpc endpoint response.
PR here... https://github.com/NethermindEth/nethermind/pull/7443 