### PR TITLE
fix: Corrects small typos in pages

### DIFF
--- a/docs/developers/plugins.md
+++ b/docs/developers/plugins.md
@@ -25,7 +25,7 @@ Plugins that you can write:
 | Tracers             | Custom, powerful EVM tracers capable of extracting elements of EVM execution in real time.                                                                                                     |
 | CLI                 | Additional modules for Nethermind CLI that can allow you build some quick scratchpad style JavaScript based behaviors.                                                                         |
 
-**Note:** When writing a plugin be carefull about exceptions you throw. Especially if you are hooking up event handlers
+**Note:** When writing a plugin be careful about exceptions you throw. Especially if you are hooking up event handlers
 on some core objects like BlockProcessor or BlockTree. Those exceptions can bring the node down. This is by design. Its
 responsibility of plugin writer to correctly handle those exceptions.
 

--- a/docs/fundamentals/logs.md
+++ b/docs/fundamentals/logs.md
@@ -83,7 +83,7 @@ You will see some information about the sync progress, like below:
 ![Fast blocks sync logs](/img/getting\_started\_log\_0.png)
 
 When the fast blocks stage finishes, there will be some period of downloading blocks between the `pivot` and
-the`latest blocks` which will have some additional info:
+the `latest blocks` which will have some additional info:
 
 1. Shows the last entry from the fast blocks stage.
 2. Shows the mode transition moment.

--- a/docs/fundamentals/pruning.md
+++ b/docs/fundamentals/pruning.md
@@ -168,6 +168,6 @@ The `Pruning.CacheMb` configuration option determines the size, in MB, of the me
 For pruning, keep in mind the following:
 
 - Full pruning is a cumbersome task, but it's performed in the background, so the node continues progressing and following the chain.
-- The process' heaviness may affect the effectiveness of the validator rewards. Still, since it's executed only once every few months, it shouldn't have a significant impact on overall results (we've xperienced approximately 5–10% loss of rewards during full pruning).
+- The process' heaviness may affect the effectiveness of the validator rewards. Still, since it's executed only once every few months, it shouldn't have a significant impact on overall results (we've experienced approximately 5–10% loss of rewards during full pruning).
 - Ensure that your storage has at least 250 GB of free space after syncing the node. Otherwise, full pruning will never complete successfully.
 - Several things can be done to reduce the size of the database after syncing: setting `Sync.AncientBodiesBarrier` and `Sync.AncientReceiptsBarrier` to a proper value higher than 0, using a consensus client that requires less storage, and setting logs to the lowest level to avoid log spamming.

--- a/docs/interacting/json-rpc-ns/eth.md
+++ b/docs/interacting/json-rpc-ns/eth.md
@@ -1379,7 +1379,7 @@ curl localhost:8545 \
 
 ### eth_getTransactionCount
 
-Returns account nonce (number of trnsactions from the account since genesis) at the given block number
+Returns account nonce (number of transactions from the account since genesis) at the given block number
 
 <Tabs>
 <TabItem value="params" label="Parameters">

--- a/docs/validators/aura.md
+++ b/docs/validators/aura.md
@@ -46,7 +46,7 @@ The keyfile must be stored in the `keystore` directory located in the Nethermind
 Here is an example of recommended settings for a validator. The most convenient way to configure these settings is either defining them in the configuration file or passing them as environment variables.
 
 - `Init.IsMining`: `true`
-- `Init.MemoryHint`: Can be left unspecified. It's recommended to configure it accordingly to the machine specification(for Eneergy Web, 768000000 is enough).
+- `Init.MemoryHint`: Can be left unspecified. It's recommended to configure it accordingly to the machine specification (for Energy Web, 768000000 is enough).
 - `EthStats` namespace parameters if you want to report node status to Ethstats for your network.
 - `Metrics` namespace parameters to enable node monitoring.
 - `KeyStore.PasswordFiles`: The  path to the file containing the password for the mining private key.

--- a/versioned_docs/version-1.29.0/fundamentals/sync.md
+++ b/versioned_docs/version-1.29.0/fundamentals/sync.md
@@ -168,7 +168,7 @@ Explanation of some data in the logs:
 * at the beginning you may see a _'Waiting for peers...'_ message while the node is trying to discover nodes that it can
   sync with.
 * _'Downloaded 1234/8000000'_ shows the number of unprocessed blocks (with transactions) downloaded from the network.
-  For `mainnet`this value may be slower than processing at first but very quickly you will see blocks being downloaded
+  For `mainnet` this value may be slower than processing at first but very quickly you will see blocks being downloaded
   much faster than processed. Empty blocks can be as small as 512 bytes (just headers without transactions) and full
   blocks with heavy transactions can reach a few hundred kilobytes. We display both current download speed (calculated
   in the last second) and average (total) speed since starting the node.


### PR DESCRIPTION
See diff for ease of use 

But they include general typos, no space between variable names and words in sentences etc