### PR TITLE
docs: fix proof_getTransactionReceipt description

### DIFF
--- a/docs/interacting/json-rpc-ns/proof.md
+++ b/docs/interacting/json-rpc-ns/proof.md
@@ -62,7 +62,7 @@ curl localhost:8545 \
 
 ### proof_getTransactionReceipt
 
-This function should return the same result as `eth_call` and also proofs of all used accounts and their storages and serialized block headers.
+This function returns the same data as `eth_getTransactionReceipt` plus Merkle-Patricia proofs of the transaction's inclusion in the block's `transactionsRoot` and of the receipt's inclusion in the block's `receiptsRoot`. When `includeHeader` is `true`, the RLP-encoded block header is also returned, allowing the proofs to be verified against the block's roots.
 
 <Tabs>
 <TabItem value="params" label="Parameters">
@@ -134,4 +134,3 @@ curl localhost:8545 \
 
 </TabItem>
 </Tabs>
-

--- a/docs/interacting/json-rpc-ns/proof.md
+++ b/docs/interacting/json-rpc-ns/proof.md
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 
 ### proof_getTransactionByHash
 
-This function returns the same result as `eth_getTransactionReceipt` and also a tx proof, receipt proof and serialized block headers.
+This function returns the same data as `eth_getTransactionByHash` plus a Merkle-Patricia proof of the transaction's inclusion in the block's `transactionsRoot`. When `includeHeader` is `true`, the RLP-encoded block header is also returned, allowing the proof to be verified against the block's `transactionsRoot`.
 
 <Tabs>
 <TabItem value="params" label="Parameters">
@@ -46,7 +46,7 @@ curl localhost:8545 \
 ```
 
 `result`: _object_
-  - `blockHeader`: _string_ (hex data)
+  - `blockHeader`: optional _string_ (hex data), returned when `includeHeader` is `true`
   - `transaction`: _object_
     - `blockHash`: _string_ (hash)
     - `blockNumber`: _string_ (hex integer)
@@ -99,7 +99,7 @@ curl localhost:8545 \
 ```
 
 `result`: _object_
-  - `blockHeader`: _string_ (hex data)
+  - `blockHeader`: optional _string_ (hex data), returned when `includeHeader` is `true`
   - `receipt`: _object_
     - `blobGasPrice`: _string_ (hex integer)
     - `blobGasUsed`: _string_ (hex integer)


### PR DESCRIPTION
Fixes #339

This PR aligns the `proof` namespace docs with the current RPC contract in `src/Nethermind/Nethermind.JsonRpc/Modules/Proof/IProofRpcModule.cs`.

Failure mechanism:
- `proof_getTransactionReceipt` was documented as if it behaved like `eth_call` and returned account/storage proofs.
- `proof_getTransactionByHash` was also misdescribed as returning the result of `eth_getTransactionReceipt`.
- Both sections documented `blockHeader` as unconditional even though it is gated by `includeHeader`.

Semantic change:
- `proof_getTransactionByHash` now matches the implemented behavior: `eth_getTransactionByHash` data plus a transaction inclusion proof against `transactionsRoot`, with optional RLP block header.
- `proof_getTransactionReceipt` now matches the implemented behavior: `eth_getTransactionReceipt` data plus transaction and receipt inclusion proofs against `transactionsRoot` and `receiptsRoot`, with optional RLP block header.
- `blockHeader` is now documented as optional in both response sections.

Preserved invariant:
- No runtime behavior changes; this is a docs-only correction to match the existing RPC interface metadata.

Testing:
- `npm run build`
