### PR TITLE
docs: add BalanceViewer configuration namespace

### DIFF
--- a/docs/fundamentals/configuration.md
+++ b/docs/fundamentals/configuration.md
@@ -263,6 +263,63 @@ The configuration options are case-sensitive and can be defined only once unless
   The address of the transaction priority contract to use when selecting transactions from the transaction pool. Defaults to `null`.
 
 
+### BalanceViewer
+
+- #### `BalanceViewer.Enabled` \{#balanceviewer-enabled\}
+
+  <Tabs groupId="usage">
+  <TabItem value="cli" label="CLI">
+  ```
+  --balanceviewer-enabled [true|false]
+  --BalanceViewer.Enabled [true|false]
+  ```
+  </TabItem>
+  <TabItem value="env" label="Environment variable">
+  ```
+  NETHERMIND_BALANCEVIEWERCONFIG_ENABLED=true|false
+  ```
+  </TabItem>
+  <TabItem value="config" label="Configuration file">
+  ```json
+  {
+    "BalanceViewer": {
+      "Enabled": true|false
+    }
+  }
+  ```
+  </TabItem>
+  </Tabs>
+
+  Whether to serve the balance viewer UI at the `/balances` path of the JSON-RPC HTTP endpoint. Allowed values: `true` `false`. Defaults to `true`.
+
+- #### `BalanceViewer.SiblingProbePorts` \{#balanceviewer-siblingprobeports\}
+
+  <Tabs groupId="usage">
+  <TabItem value="cli" label="CLI">
+  ```
+  --balanceviewer-siblingprobeports <value>
+  --BalanceViewer.SiblingProbePorts <value>
+  ```
+  </TabItem>
+  <TabItem value="env" label="Environment variable">
+  ```
+  NETHERMIND_BALANCEVIEWERCONFIG_SIBLINGPROBEPORTS=<value>
+  ```
+  </TabItem>
+  <TabItem value="config" label="Configuration file">
+  ```json
+  {
+    "BalanceViewer": {
+      "SiblingProbePorts": <value>
+    }
+  }
+  ```
+  </TabItem>
+  </Tabs>
+
+  Comma-separated localhost ports probed to discover sibling Nethermind nodes on other chains for the multi-chain balance view. Defaults to `8545,8546,8547,8548,8549,8550`.
+
+
 ### BalRecorder
 
 - #### `BalRecorder.Path` \{#balrecorder-path\}


### PR DESCRIPTION
## What

Adds the missing **`BalanceViewer`** namespace to the configuration reference (`docs/fundamentals/configuration.md`):

- `BalanceViewer.Enabled` — **defaults to `true`** (the plugin serves the `/balances` UI and its token/NFT auto-detection out of the box)
- `BalanceViewer.SiblingProbePorts` — defaults to `8545,8546,8547,8548,8549,8550`

## Why

The config reference documents every config namespace except `BalanceViewer`, so it doesn't reflect that the balance viewer (and its detection) ships **on by default**. This came up when verifying the default: the code (`IBalanceViewerConfig.Enabled`, `DefaultValue = "true"`, plus the plugin being registered in `NethermindPlugins`) confirms it is enabled by default, but the docs were silent.

## Notes

- Draft: the balance viewer feature is still on a feature branch (`feature/balance-viewer-token-detection`, Nethermind PR #12446) and not yet released.
- The section mirrors the `DocGen` output format, so the release-time `Update docs` workflow will reproduce it automatically once the feature ships — this just documents it early / corrects the omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)