### PR TITLE
Document history pruning modes and the EraE format

### DIFF
--- a/docs/fundamentals/history-pruning.md
+++ b/docs/fundamentals/history-pruning.md
@@ -47,8 +47,8 @@ Receipts are stored slim, as `rlp([txType, postStateOrStatus, cumulativeGas, log
 
 The `Era.*` options and `admin_importHistory`/`admin_exportHistory` described below apply to Era1. EraE has its own equivalents:
 
-- Import: [`EraE.ImportDirectory`](./configuration.md#erae-importdirectory), or the [`admin_importEraHistory`](../interacting/json-rpc-ns/admin.md#admin_importerahistory) JSON-RPC method.
-- Export: [`EraE.ExportDirectory`](./configuration.md#erae-exportdirectory), or the [`admin_exportEraHistory`](../interacting/json-rpc-ns/admin.md#admin_exporterahistory) JSON-RPC method. Exporting post-Merge blocks requires [`EraE.BeaconNodeUrl`](./configuration.md#erae-beaconnodeurl), which supplies the beacon block and state roots.
+- Import: [`EraE.ImportDirectory`](./configuration.md#erae-importdirectory), or the `admin_importEraHistory` JSON-RPC method.
+- Export: [`EraE.ExportDirectory`](./configuration.md#erae-exportdirectory), or the `admin_exportEraHistory` JSON-RPC method. Exporting post-Merge blocks requires [`EraE.BeaconNodeUrl`](./configuration.md#erae-beaconnodeurl), which supplies the beacon block and state roots.
 - Range and verification: [`EraE.From`](./configuration.md#erae-from), [`EraE.To`](./configuration.md#erae-to) (`0` means head), and [`EraE.TrustedAccumulatorFile`](./configuration.md#erae-trustedaccumulatorfile).
 
 ### Remote archives

--- a/docs/fundamentals/history-pruning.md
+++ b/docs/fundamentals/history-pruning.md
@@ -6,8 +6,20 @@ sidebar_position: 7
 History pruning is a feature set that aims to reduce storage space requirements for a node by removing old historical data. The goal is to remove the requirement from nodes to store all the historical data but ensure the old data is preserved and accessible for anyone who needs it. For details, see [EIP-4444][eip444].
 
 :::info
-History pruning is enabled by default for the networks supporting it. To disable, set [`Sync.AncientBodiesBarrier`](./configuration.md#sync-ancientbodiesbarrier) and [`Sync.AncientReceiptsBarrier`](./configuration.md#sync-ancientreceiptsbarrier) to `0`.
+On networks that support it, a fresh sync stops downloading bodies and receipts below the ancient barriers, so the node holds history only from that point onwards. To download the entire history instead, set [`Sync.AncientBodiesBarrier`](./configuration.md#sync-ancientbodiesbarrier) and [`Sync.AncientReceiptsBarrier`](./configuration.md#sync-ancientreceiptsbarrier) to `0`.
+
+Removing history that is already stored is a separate, opt-in step controlled by [`History.Pruning`](./configuration.md#history-pruning).
 :::
+
+## Pruning modes
+
+[`History.Pruning`](./configuration.md#history-pruning) selects how stored historical blocks and receipts are removed as the node runs.
+
+- `Disabled` (default) — nothing already stored is removed.
+- `UseAncientBarriers` — prunes everything below the ancient barriers cutoff, matching what a fresh sync would have downloaded.
+- `Rolling` — keeps a moving window of the most recent [`History.RetentionEpochs`](./configuration.md#history-retentionepochs) epochs and prunes below it as the head advances. The configured window must be at least the `minHistoryRetentionEpochs` chainspec parameter of the network, and a node that has just synced only starts pruning once its stored history grows past the window.
+
+Pruning never removes the genesis block or anything at or above the sync pivot. Use [`History.PruningInterval`](./configuration.md#history-pruninginterval) and [`History.PruningTimeoutSeconds`](./configuration.md#history-pruningtimeoutseconds) to control how often it runs and how long a single pass may take.
 
 ## Era1 format
 
@@ -22,6 +34,26 @@ block-index := starting-number | index | index | index ... | count
 ```
 
 Block headers, bodies, and receipts are compressed using the [Snappy framing format](https://github.com/google/snappy/blob/main/framing_format.txt). Each file contains a block index for fast lookup and an [epoch accumulator](https://github.com/ethereum/portal-network-specs/blob/master/history/history-network.md#the-historical-hashes-accumulator) for verification. The epoch accumulator can verify the entire archive with accumulators from a trusted source. It also allows a node to download a block header with a Merkle proof, proving it belongs to a particular epoch.
+
+## EraE format
+
+EraE is the post-Merge archival format, specified in [ere.md](https://github.com/eth-clients/e2store-format-specs/blob/main/formats/ere.md). An EraE file holds up to 8192 blocks and is laid out as follows:
+
+```
+Version | CompressedHeader* | CompressedBody* | CompressedSlimReceipts* | TotalDifficulty* | AccumulatorRoot? | ComponentIndex
+```
+
+Receipts are stored slim, as `rlp([txType, postStateOrStatus, cumulativeGas, logs])` with no bloom filter; readers recompute it from the logs. Exported files use the `.ere` extension and carry the `noproofs` profile postfix, since Nethermind does not write `Proof` entries. The older `.erae` extension is still accepted on import.
+
+The `Era.*` options and `admin_importHistory`/`admin_exportHistory` described below apply to Era1. EraE has its own equivalents:
+
+- Import: [`EraE.ImportDirectory`](./configuration.md#erae-importdirectory), or the [`admin_importEraHistory`](../interacting/json-rpc-ns/admin.md#admin_importerahistory) JSON-RPC method.
+- Export: [`EraE.ExportDirectory`](./configuration.md#erae-exportdirectory), or the [`admin_exportEraHistory`](../interacting/json-rpc-ns/admin.md#admin_exporterahistory) JSON-RPC method. Exporting post-Merge blocks requires [`EraE.BeaconNodeUrl`](./configuration.md#erae-beaconnodeurl), which supplies the beacon block and state roots.
+- Range and verification: [`EraE.From`](./configuration.md#erae-from), [`EraE.To`](./configuration.md#erae-to) (`0` means head), and [`EraE.TrustedAccumulatorFile`](./configuration.md#erae-trustedaccumulatorfile).
+
+### Remote archives
+
+Set [`EraE.RemoteBaseUrl`](./configuration.md#erae-remotebaseurl) to a remote EraE server to download missing epoch files on demand instead of providing them locally. Downloads are checksummed against the server's `checksums_sha256.txt` manifest and cached in [`EraE.RemoteDownloadDirectory`](./configuration.md#erae-remotedownloaddirectory), which defaults to the import directory.
 
 ## Import
 

--- a/docs/fundamentals/history-pruning.md
+++ b/docs/fundamentals/history-pruning.md
@@ -16,7 +16,7 @@ Removing history that is already stored is a separate, opt-in step controlled by
 [`History.Pruning`](./configuration.md#history-pruning) selects how stored historical blocks and receipts are removed as the node runs.
 
 - `Disabled` (default) — nothing already stored is removed.
-- `UseAncientBarriers` — prunes everything below the ancient barriers cutoff, matching what a fresh sync would have downloaded.
+- `UseAncientBarriers` — removes stored block bodies and receipts below the lower of the two ancient barriers.
 - `Rolling` — keeps a moving window of the most recent [`History.RetentionEpochs`](./configuration.md#history-retentionepochs) epochs and prunes below it as the head advances. The configured window must be at least the `minHistoryRetentionEpochs` chainspec parameter of the network, and a node that has just synced only starts pruning once its stored history grows past the window.
 
 Pruning never removes the genesis block or anything at or above the sync pivot. Use [`History.PruningInterval`](./configuration.md#history-pruninginterval) and [`History.PruningTimeoutSeconds`](./configuration.md#history-pruningtimeoutseconds) to control how often it runs and how long a single pass may take.
@@ -37,23 +37,23 @@ Block headers, bodies, and receipts are compressed using the [Snappy framing fo
 
 ## EraE format
 
-EraE is the post-Merge archival format, specified in [ere.md](https://github.com/eth-clients/e2store-format-specs/blob/main/formats/ere.md). An EraE file holds up to 8192 blocks and is laid out as follows:
+EraE is the archival format used for post-Merge history, as specified in [ere.md](https://github.com/eth-clients/e2store-format-specs/blob/main/formats/ere.md). An EraE file holds up to 8192 blocks and is laid out as follows:
 
 ```
 Version | CompressedHeader* | CompressedBody* | CompressedSlimReceipts* | TotalDifficulty* | AccumulatorRoot? | ComponentIndex
 ```
 
-Receipts are stored slim, as `rlp([txType, postStateOrStatus, cumulativeGas, logs])` with no bloom filter; readers recompute it from the logs. Exported files use the `.ere` extension and carry the `noproofs` profile postfix, since Nethermind does not write `Proof` entries. The older `.erae` extension is still accepted on import.
+Receipts are stored slim, as `rlp([txType, postStateOrStatus, cumulativeGas, logs])` with no bloom filter; readers recompute it from the logs. Exported files use the `.ere` extension and carry the `noproofs` profile suffix, since Nethermind does not write `Proof` entries. The older `.erae` extension is still accepted on import.
 
 The `Era.*` options and `admin_importHistory`/`admin_exportHistory` described below apply to Era1. EraE has its own equivalents:
 
 - Import: [`EraE.ImportDirectory`](./configuration.md#erae-importdirectory), or the `admin_importEraHistory` JSON-RPC method.
-- Export: [`EraE.ExportDirectory`](./configuration.md#erae-exportdirectory), or the `admin_exportEraHistory` JSON-RPC method. Exporting post-Merge blocks requires [`EraE.BeaconNodeUrl`](./configuration.md#erae-beaconnodeurl), which supplies the beacon block and state roots.
-- Range and verification: [`EraE.From`](./configuration.md#erae-from), [`EraE.To`](./configuration.md#erae-to) (`0` means head), and [`EraE.TrustedAccumulatorFile`](./configuration.md#erae-trustedaccumulatorfile).
+- Export: [`EraE.ExportDirectory`](./configuration.md#erae-exportdirectory), or the `admin_exportEraHistory` JSON-RPC method. Set [`EraE.BeaconNodeUrl`](./configuration.md#erae-beaconnodeurl) to supply beacon block and state roots during post-Merge export.
+- Range and verification: [`EraE.From`](./configuration.md#erae-from), [`EraE.To`](./configuration.md#erae-to), and [`EraE.TrustedAccumulatorFile`](./configuration.md#erae-trustedaccumulatorfile). For export, `EraE.To` set to `0` means the node's current head; for import, it means the last block available in the archive.
 
 ### Remote archives
 
-Set [`EraE.RemoteBaseUrl`](./configuration.md#erae-remotebaseurl) to a remote EraE server to download missing epoch files on demand instead of providing them locally. Downloads are checksummed against the server's `checksums_sha256.txt` manifest and cached in [`EraE.RemoteDownloadDirectory`](./configuration.md#erae-remotedownloaddirectory), which defaults to the import directory.
+When importing, set [`EraE.RemoteBaseUrl`](./configuration.md#erae-remotebaseurl) to download archive files that are missing from the import directory. You must still provide a local source directory through `EraE.ImportDirectory` or the `admin_importEraHistory` method. Downloaded files are verified against the SHA-256 hashes in the server's `checksums_sha256.txt` manifest and cached in [`EraE.RemoteDownloadDirectory`](./configuration.md#erae-remotedownloaddirectory), which defaults to the import directory.
 
 ## Import
 

--- a/docs/interacting/json-rpc-ns/admin.md
+++ b/docs/interacting/json-rpc-ns/admin.md
@@ -134,6 +134,51 @@ The data directory path as a string.
 </TabItem>
 </Tabs>
 
+### admin_exportEraHistory
+
+Exports a range of historic blocks in erae format.
+
+<Tabs>
+<TabItem value="params" label="Parameters">
+
+1. `destinationPath`: _string_
+
+2. `from`: _string_ (hex integer)
+
+3. `to`: _string_ (hex integer)
+
+
+</TabItem>
+<TabItem value="request" label="Request" default>
+
+```bash
+curl localhost:8545 \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --data '{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "admin_exportEraHistory",
+      "params": [destinationPath, from, to]
+    }'
+```
+
+</TabItem>
+<TabItem value="response" label="Response">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": result
+}
+```
+
+`result`: _string_
+
+</TabItem>
+</Tabs>
+
 ### admin_exportHistory
 
 Exports a range of historic block in era1 format.
@@ -160,6 +205,53 @@ curl localhost:8545 \
       "id": 0,
       "method": "admin_exportHistory",
       "params": [destinationPath, from, to]
+    }'
+```
+
+</TabItem>
+<TabItem value="response" label="Response">
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 0,
+  "result": result
+}
+```
+
+`result`: _string_
+
+</TabItem>
+</Tabs>
+
+### admin_importEraHistory
+
+Imports a range of historic blocks from an erae directory.
+
+<Tabs>
+<TabItem value="params" label="Parameters">
+
+1. `sourcePath`: _string_
+
+2. `from`: _string_ (hex integer)
+
+3. `to`: _string_ (hex integer)
+
+4. `accumulatorFile`: _string_
+
+
+</TabItem>
+<TabItem value="request" label="Request" default>
+
+```bash
+curl localhost:8545 \
+  -X POST \
+  -H "Content-Type: application/json" \
+  --data '{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "admin_importEraHistory",
+      "params": [sourcePath, from, to, accumulatorFile]
     }'
 ```
 

--- a/docs/interacting/json-rpc-ns/admin.md
+++ b/docs/interacting/json-rpc-ns/admin.md
@@ -134,51 +134,6 @@ The data directory path as a string.
 </TabItem>
 </Tabs>
 
-### admin_exportEraHistory
-
-Exports a range of historic blocks in erae format.
-
-<Tabs>
-<TabItem value="params" label="Parameters">
-
-1. `destinationPath`: _string_
-
-2. `from`: _string_ (hex integer)
-
-3. `to`: _string_ (hex integer)
-
-
-</TabItem>
-<TabItem value="request" label="Request" default>
-
-```bash
-curl localhost:8545 \
-  -X POST \
-  -H "Content-Type: application/json" \
-  --data '{
-      "jsonrpc": "2.0",
-      "id": 0,
-      "method": "admin_exportEraHistory",
-      "params": [destinationPath, from, to]
-    }'
-```
-
-</TabItem>
-<TabItem value="response" label="Response">
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 0,
-  "result": result
-}
-```
-
-`result`: _string_
-
-</TabItem>
-</Tabs>
-
 ### admin_exportHistory
 
 Exports a range of historic block in era1 format.
@@ -205,53 +160,6 @@ curl localhost:8545 \
       "id": 0,
       "method": "admin_exportHistory",
       "params": [destinationPath, from, to]
-    }'
-```
-
-</TabItem>
-<TabItem value="response" label="Response">
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 0,
-  "result": result
-}
-```
-
-`result`: _string_
-
-</TabItem>
-</Tabs>
-
-### admin_importEraHistory
-
-Imports a range of historic blocks from an erae directory.
-
-<Tabs>
-<TabItem value="params" label="Parameters">
-
-1. `sourcePath`: _string_
-
-2. `from`: _string_ (hex integer)
-
-3. `to`: _string_ (hex integer)
-
-4. `accumulatorFile`: _string_
-
-
-</TabItem>
-<TabItem value="request" label="Request" default>
-
-```bash
-curl localhost:8545 \
-  -X POST \
-  -H "Content-Type: application/json" \
-  --data '{
-      "jsonrpc": "2.0",
-      "id": 0,
-      "method": "admin_importEraHistory",
-      "params": [sourcePath, from, to, accumulatorFile]
     }'
 ```
 


### PR DESCRIPTION
Two gaps on the history pruning page.

**Pruning modes.** `History.Pruning` was undocumented, so there was no description of `Rolling` anywhere, even though it has shipped since 1.33. Added the three modes, the retention floor rule, and the genesis/sync-pivot guarantee.

**Wording of the intro note.** It said history pruning is enabled by default, which reads as "stored history is deleted by default". What is on by default is the barrier-limited download; deleting stored history is opt-in via `History.Pruning`. Split the two.

**EraE format.** The page only covered Era1. Added the post-Merge format: layout, slim receipts, `.ere` extension with the `noproofs` profile, the `EraE.*` import/export options, and remote archive downloads.

The page names `admin_importEraHistory` and `admin_exportEraHistory` without linking into the JSON-RPC reference, because that reference is generated and does not contain them yet: DocGen's assembly list omits `Nethermind.EraE`, so the two methods have never been emitted even though they ship. NethermindEth/nethermind#12873 fixes the generator, and the entries appear the next time the reference is regenerated.
