### PR TITLE
docs: JSON-RPC response streaming for traces and logs

### DIFF
--- a/docs/interacting/json-rpc-server.md
+++ b/docs/interacting/json-rpc-server.md
@@ -210,4 +210,22 @@ For more information, see [Viem documentation](https://viem.sh/docs/getting-star
 </TabItem>
 </Tabs>
 
+## Streaming responses
+
+Some methods can return a response far larger than the request that asked for it: a block trace, or a log query over a wide range. Nethermind writes those responses to the transport as it produces them, instead of building the whole response in memory first. The memory a request costs is then bounded by the stream rather than by the size of its result, and the first bytes reach the caller before the node has finished the work.
+
+### Traces
+
+[`JsonRpc.EnableTracingStreamMode`](../fundamentals/configuration.md#jsonrpc-enabletracingstreammode) streams the `debug_trace*` and `trace_*` responses as the transaction executes. It is enabled by default. A `debug_trace*` call can override it for that request with the `streamMode` option, for example:
+
+```bash
+cast rpc --rpc-url http://localhost:8545 debug_traceBlockByNumber latest '{"tracer":"callTracer","streamMode":false}'
+```
+
+Streaming bounds the memory of a trace and lowers the time to the first byte. It does not change how long the trace takes to produce, since tracing re-executes the block.
+
+### Logs
+
+[`JsonRpc.EnableLogsStreamMode`](../fundamentals/configuration.md#jsonrpc-enablelogsstreammode) streams the `eth_getLogs` and `eth_getFilterLogs` responses as matching logs are found. It is disabled by default, because it changes what a caller receives when a query is too large: instead of buffering the whole result and returning a limit error, a streamed response stops at [`JsonRpc.MaxLogsPerResponse`](../fundamentals/configuration.md#jsonrpc-maxlogsperresponse) or [`JsonRpc.MaxLogsResponseBodySize`](../fundamentals/configuration.md#jsonrpc-maxlogsresponsebodysize) and ends there. Authenticated requests are not subject to those limits.
+
 The exhaustive list of supported JSON-RPC methods can be found under the JSON-RPC namespaces.


### PR DESCRIPTION
## What

Documents JSON-RPC response streaming, which shipped in 1.39.0 and had no prose anywhere: a new `Streaming responses` section on the JSON-RPC server page, with a subsection each for traces and logs.

The two configuration options already appear in the generated configuration reference, but nothing told an operator what streaming does, that traces stream by default, or why the logs one is opt-in. Operators running 1.39 have the trace behaviour today without knowing it.

## Content

- What streaming is for: a response far larger than the request that asked for it is written to the transport as it is produced, so the memory a request costs is bounded by the stream rather than by the size of its result, and the first bytes arrive before the work finishes.
- Traces: `JsonRpc.EnableTracingStreamMode`, on by default, with the per-call `streamMode` override on `debug_trace*` and a Cast example. States plainly that streaming bounds memory and lowers time to first byte but does not make a trace faster, since tracing re-executes the block.
- Logs: `JsonRpc.EnableLogsStreamMode`, off by default, and the reason it is opt-in: a streamed response stops at the per-response limits instead of buffering the whole result and returning a limit error, and authenticated requests are not subject to those limits.

## Style

Behaviour only, no numbers; every option links to its entry in the generated configuration reference. All four anchors this section links to already exist there, so it adds no broken anchor (the build's remaining warnings are the pre-existing `FlatDb.History*` and `ArchiveProof*` ones, which appear when the reference is regenerated for 2.0).
